### PR TITLE
chore(deps): bump .NET SDK to 10.0.103 and update NuGet packages

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "10.0.102"
+    "version": "10.0.103"
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"

--- a/src/Cake.Bridge.DependencyInjection.Example/Cake.Bridge.DependencyInjection.Example.csproj
+++ b/src/Cake.Bridge.DependencyInjection.Example/Cake.Bridge.DependencyInjection.Example.csproj
@@ -11,7 +11,7 @@
 
     <PackageReference Include="Spectre.Console" Version="0.54.0" />
     <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
-    <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.22.0" />
+    <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.23.0" />
     <PackageReference Include="Cake.Core" Version="6.0.0" />
     <PackageReference Include="Cake.Common" Version="6.0.0" />
   </ItemGroup>

--- a/src/Cake.Bridge.DependencyInjection.Testing.Tests/Cake.Bridge.DependencyInjection.Testing.Tests.csproj
+++ b/src/Cake.Bridge.DependencyInjection.Testing.Tests/Cake.Bridge.DependencyInjection.Testing.Tests.csproj
@@ -28,9 +28,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlead.Testing.MockHttp" Version="2026.1.14.568" />
+    <PackageReference Include="Devlead.Testing.MockHttp" Version="2026.2.11.605" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="Verify.XunitV3" Version="31.12.3" />
+    <PackageReference Include="Verify.XunitV3" Version="31.12.4" />
     <PackageReference Include="Verify.DiffPlex" Version="3.1.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />

--- a/src/Cake.Bridge.DependencyInjection.Testing/Cake.Bridge.DependencyInjection.Testing.csproj
+++ b/src/Cake.Bridge.DependencyInjection.Testing/Cake.Bridge.DependencyInjection.Testing.csproj
@@ -9,11 +9,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.12" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.13" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.10.0" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.10.0" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.2.0" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.3.0" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Cake.Core" Version="6.0.0" />
     <PackageReference Include="Cake.Testing" Version="6.0.0" />
   </ItemGroup>

--- a/src/Cake.Bridge.DependencyInjection/Cake.Bridge.DependencyInjection.csproj
+++ b/src/Cake.Bridge.DependencyInjection/Cake.Bridge.DependencyInjection.csproj
@@ -7,8 +7,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.12" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.2" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.13" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Cake.Core" Version="6.0.0" />
     <InternalsVisibleTo Include="Cake.Bridge.DependencyInjection.Testing" />
   </ItemGroup>


### PR DESCRIPTION
- global.json: SDK 10.0.102 → 10.0.103
- Microsoft.Extensions.DependencyInjection: 9.0.12 → 9.0.13, 10.0.2 → 10.0.3
- Microsoft.Extensions.TimeProvider.Testing: 10.2.0 → 10.3.0 (net10.0)
- Spectre.Console.Cli.Extensions.DependencyInjection: 0.22.0 → 0.23.0
- Devlead.Testing.MockHttp: 2026.1.14.568 → 2026.2.11.605
- Verify.XunitV3: 31.12.3 → 31.12.4