### PR TITLE
chore(deps): bump Spectre.Console and Microsoft.Extensions net10 packages

### DIFF
--- a/src/Cake.Bridge.DependencyInjection.Example/Cake.Bridge.DependencyInjection.Example.csproj
+++ b/src/Cake.Bridge.DependencyInjection.Example/Cake.Bridge.DependencyInjection.Example.csproj
@@ -9,9 +9,9 @@
 
   <ItemGroup>
 
-    <PackageReference Include="Spectre.Console" Version="0.54.0" />
-    <PackageReference Include="Spectre.Console.Cli" Version="0.53.1" />
-    <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.23.0" />
+    <PackageReference Include="Spectre.Console" Version="0.55.2" />
+    <PackageReference Include="Spectre.Console.Cli" Version="0.55.0" />
+    <PackageReference Include="Spectre.Console.Cli.Extensions.DependencyInjection" Version="0.25.0" />
     <PackageReference Include="Cake.Core" Version="6.1.0" />
     <PackageReference Include="Cake.Common" Version="6.1.0" />
   </ItemGroup>

--- a/src/Cake.Bridge.DependencyInjection.Example/Commands/CakeContextCommand.cs
+++ b/src/Cake.Bridge.DependencyInjection.Example/Commands/CakeContextCommand.cs
@@ -9,7 +9,7 @@ namespace Cake.Bridge.DependencyInjection.Example.Commands;
 // ReSharper disable once ClassNeverInstantiated.Global
 public class CakeContextCommand : Command<CakeContextSettings>
 {
-    public override int Execute(CommandContext context, CakeContextSettings settings, CancellationToken token)
+    protected override int Execute(CommandContext context, CakeContextSettings settings, CancellationToken token)
     {
         var absoluteSourcePath = settings.Context.MakeAbsolute(settings.SourcePath);
         var directory = settings.Context.FileSystem.GetDirectory(absoluteSourcePath);

--- a/src/Cake.Bridge.DependencyInjection.Example/Commands/ScriptHostCommand.cs
+++ b/src/Cake.Bridge.DependencyInjection.Example/Commands/ScriptHostCommand.cs
@@ -12,7 +12,7 @@ public class ScriptHostCommand : AsyncCommand<ScriptHostSettings>
     private IScriptHost ScriptHost { get; }
     private BridgeArguments BridgeArguments { get; }
 
-    public override async Task<int> ExecuteAsync(CommandContext context, ScriptHostSettings settings, CancellationToken token)
+    protected override async Task<int> ExecuteAsync(CommandContext context, ScriptHostSettings settings, CancellationToken token)
     {
         if (settings.Exclusive)
         {

--- a/src/Cake.Bridge.DependencyInjection.Testing/Cake.Bridge.DependencyInjection.Testing.csproj
+++ b/src/Cake.Bridge.DependencyInjection.Testing/Cake.Bridge.DependencyInjection.Testing.csproj
@@ -10,10 +10,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.10.0" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.10.0" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Cake.Core" Version="6.1.0" />
     <PackageReference Include="Cake.Testing" Version="6.1.0" />
   </ItemGroup>

--- a/src/Cake.Bridge.DependencyInjection/Cake.Bridge.DependencyInjection.csproj
+++ b/src/Cake.Bridge.DependencyInjection/Cake.Bridge.DependencyInjection.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" Condition="'$(TargetFramework)' == 'net8.0'" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.16" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" Condition="'$(TargetFramework)' == 'net10.0'" />
     <PackageReference Include="Cake.Core" Version="6.1.0" />
     <InternalsVisibleTo Include="Cake.Bridge.DependencyInjection.Testing" />
   </ItemGroup>


### PR DESCRIPTION
Update package references and align Example CLI commands with Spectre.Console.Cli 0.55.

Spectre.Console (Example):
- Spectre.Console 0.54.0 → 0.55.2
- Spectre.Console.Cli 0.53.1 → 0.55.0
- Spectre.Console.Cli.Extensions.DependencyInjection 0.23.0 → 0.25.0

Microsoft.Extensions (net10.0):
- Microsoft.Extensions.DependencyInjection 10.0.5 → 10.0.8 (Cake.Bridge.DependencyInjection, Cake.Bridge.DependencyInjection.Testing)
- Microsoft.Extensions.TimeProvider.Testing 10.4.0 → 10.6.0 (Cake.Bridge.DependencyInjection.Testing)

Example: change Command Execute/ExecuteAsync overrides from public to protected to match Spectre.Console.Cli 0.55 (CakeContextCommand, ScriptHostCommand).